### PR TITLE
Fix misformatting of token.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -34,15 +34,26 @@ async fn main() {
 
 	// Get configuration
 	let config = utils::get_config();
-	let token = rbx_cookie::get_value(); // Get token from the environment
+	let machine_extracted_token = rbx_cookie::get_value(); // Get token from the environment
+
+	let token = match machine_extracted_token {
+		Some(_) => format!(".ROBLOSECURITY={}", machine_extracted_token.unwrap()),
+		None => config.token
+	};
 
 	// Create client for Roblox API
 	let roblox_client = roblox::RobloxAPI {
 		// If token isn't found in env, try using one from the config
-		token: token.unwrap_or_else(|| config.token),
+		token,
 		client: reqwest::Client::new()
 	};
 
+	/*
+		TODO: Discord may not always be open, in which case, client will fail to connect
+		and, therefore, result in an error. We should handle such case without throwing error
+		by informing the user to open Discord.exe
+	*/
+	
 	// Setup Discord IPC clients
 	let mut roblox_player = DiscordIpcClient::new(config::PLAYER_DISCORD_APP_ID).unwrap();
 	let mut roblox_studio = DiscordIpcClient::new(config::STUDIO_DISCORD_APP_ID).unwrap();

--- a/src/roblox.rs
+++ b/src/roblox.rs
@@ -31,15 +31,6 @@ pub struct UserPresence {
 	pub universe_id: Option<i64>
 }
 
-/// Formats given token to be fit to be a cookie.
-/// 
-/// eg. `"secret"` -> `".ROBLOSECURITY=secret"`
-fn token_to_cookie(token: &str) -> String {
-	// Change some possible misformatting when copying the token
-	let token_cookie = format!(".ROBLOSECURITY={}", token).replace(".ROBLOSECURITY=.ROBLOSECURITY=", ".ROBLOSECURITY=").replace("^", "");
-	return token_cookie;
-}
-
 impl RobloxAPI {
 	pub async fn get_user_auth_info(&self) -> Result<AuthInfo, Error> {
 		/*
@@ -47,7 +38,7 @@ impl RobloxAPI {
 			(specifically the userid so we can use it to get their presence)
 		*/
 		let response = self.client.get("https://users.roblox.com/v1/users/authenticated")
-			.header("Cookie", token_to_cookie(self.token.as_str()))
+			.header("Cookie", self.token.as_str())
 			.header("Accept", "application/json")
 			.send()
 			.await;
@@ -101,7 +92,7 @@ impl RobloxAPI {
 
 	pub async fn get_place_info(&self, place_id: i64) -> Result<PlaceInfo, Error> {
 		let response = self.client.get(format!("https://games.roblox.com/v1/games/multiget-place-details?placeIds={}", place_id))
-			.header("Cookie", token_to_cookie(self.token.as_str()))
+			.header("Cookie", self.token.as_str())
 			.send()
 			.await;
 
@@ -125,7 +116,7 @@ impl RobloxAPI {
 
 	pub async fn get_user_presence(&self, user_id: i64) -> Result<UserPresence, Error> {
 		let response = self.client.post("https://presence.roblox.com/v1/presence/users")
-			.header("Cookie", token_to_cookie(self.token.as_str()))
+			.header("Cookie", self.token.as_str())
 			.header("Content-Type", "application/json")
 			.body(format!("{{\"userIds\":[{}]}}", user_id))
 			.send()

--- a/src/roblox.rs
+++ b/src/roblox.rs
@@ -35,7 +35,9 @@ pub struct UserPresence {
 /// 
 /// eg. `"secret"` -> `".ROBLOSECURITY=secret"`
 fn token_to_cookie(token: &str) -> String {
-	format!(".ROBLOSECURITY={}", token)
+	// Change some possible misformatting when copying the token
+	let token_cookie = format!(".ROBLOSECURITY={}", token).replace(".ROBLOSECURITY=.ROBLOSECURITY=", ".ROBLOSECURITY=").replace("^", "");
+	return token_cookie;
 }
 
 impl RobloxAPI {
@@ -65,7 +67,7 @@ impl RobloxAPI {
 			.json::<HashMap<String, String>>()
 			.await;
 		*/
-	
+
 		let id = roblox_auth["id"].as_i64().expect("Failed to fetch user id");
 	
 		return Ok(AuthInfo {
@@ -138,7 +140,7 @@ impl RobloxAPI {
 			.json::<serde_json::Value>()
 			.await
 			.unwrap();
-	
+
 		let roblox_presence = &roblox_presence["userPresences"][0];
 
 		let presence_type_id = roblox_presence["userPresenceType"].as_i64().unwrap();


### PR DESCRIPTION
Changes the .ROBLOSECURITY token should it be misformatted. Will probably close #12 and #15.
[Also for issue #12, the Program runs in the Background, it has no UI and can only be ended using Task-Manager or `taskkill -f -im stateye.exe`]